### PR TITLE
WIP: ability to kick failed jobs back onto queue.

### DIFF
--- a/bs/job.go
+++ b/bs/job.go
@@ -44,6 +44,11 @@ func (j Job) Delete() error {
 	return j.conn.Delete(j.Id)
 }
 
+// Kicks counts how many times the job has been kicked from a buried state.
+func (j Job) Kicks() (uint64, error) {
+	return j.uint64Stat("kicks")
+}
+
 // Priority of the job, zero is most urgent, 4,294,967,295 is least.
 func (j Job) Priority() (uint32, error) {
 	pri64, err := j.uint64Stat("pri")


### PR DESCRIPTION
Background: https://github.com/99designs/cmdstalk/issues/2

TL;DR: kicking failed jobs causes them to be instantly re-buried based on their stats.

This change means each `kick` buys a job one more `release` or `timeout` before it's auto-buried.

/cc @lwc.

---

For reference, here's a sample `stats-job` output:

``` yaml

---
id: 3
tube: cmdstalk-test-465396aa983f063a
state: buried
pri: 10
age: 34
delay: 0
ttr: 1
time-left: 0
file: 0
reserves: 2
timeouts: 1
releases: 0
buries: 1
kicks: 0
```
