### PR TITLE
fea: support job count limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ cmdstalk -help
 #   -cmd="": Command to run in worker.
 #   -per-tube=1: Number of workers per tube.
 #   -tubes=[default]: Comma separated list of tubes.
+#   -max-jobs=0: Maximum number of items to process before exitting. Zero for no limit.
 
 # Watch three specific tubes.
 cmdstalk -cmd="/path/to/your/worker --your=flags --here" -tubes="one,two,three"

--- a/broker/broker.go
+++ b/broker/broker.go
@@ -5,6 +5,7 @@
 package broker
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"os"
@@ -43,6 +44,7 @@ type Broker struct {
 
 	log     *log.Logger
 	results chan<- *JobResult
+	ctx     context.Context
 }
 
 type JobResult struct {
@@ -71,13 +73,14 @@ type JobResult struct {
 }
 
 // New broker instance.
-func New(address, tube string, slot uint64, cmd string, results chan<- *JobResult) (b Broker) {
+func New(ctx context.Context, address, tube string, slot uint64, cmd string, results chan<- *JobResult) (b Broker) {
 	b.Address = address
 	b.Tube = tube
 	b.Cmd = cmd
 
 	b.log = log.New(os.Stdout, fmt.Sprintf("[%s:%d] ", tube, slot), log.LstdFlags)
 	b.results = results
+	b.ctx = ctx
 	return
 }
 
@@ -94,6 +97,7 @@ func (b *Broker) Run(ticks chan bool) {
 	b.log.Println("watching", b.Tube)
 	ts := beanstalk.NewTubeSet(conn, b.Tube)
 
+	b.log.Println("starting reserve loop (waiting for job)")
 	for {
 		if ticks != nil {
 			if _, ok := <-ticks; !ok {
@@ -101,8 +105,16 @@ func (b *Broker) Run(ticks chan bool) {
 			}
 		}
 
-		b.log.Println("reserve (waiting for job)")
-		id, body := bs.MustReserveWithoutTimeout(ts)
+		if isCancelled(b.ctx) {
+			break
+		}
+
+		id, body, err := bs.MustReserveWithTimeout(ts, 1*time.Second)
+		if err == bs.ErrTimeout {
+			// Doing this to be able to gracefully handle cancelled context.
+			continue
+		}
+
 		job := bs.NewJob(id, body, conn)
 
 		t, err := job.Timeouts()
@@ -152,6 +164,15 @@ func (b *Broker) Run(ticks chan bool) {
 	}
 
 	b.log.Println("broker finished")
+}
+
+func isCancelled(ctx context.Context) bool {
+	select {
+	case <-ctx.Done():
+		return true
+	default:
+		return false
+	}
 }
 
 func (b *Broker) executeJob(job bs.Job, shellCmd string) (result *JobResult, err error) {

--- a/broker/broker_test.go
+++ b/broker/broker_test.go
@@ -2,6 +2,7 @@ package broker
 
 import (
 	"bytes"
+	"context"
 	"log"
 	"math/rand"
 	"strconv"
@@ -23,7 +24,7 @@ func TestWorkerSuccess(t *testing.T) {
 
 	cmd := "tr [a-z] [A-Z]"
 	results := make(chan *JobResult)
-	b := New(address, tube, 0, cmd, results)
+	b := New(context.Background(), address, tube, 0, cmd, results)
 
 	ticks := make(chan bool)
 	defer close(ticks)
@@ -51,7 +52,7 @@ func TestWorkerFailure(t *testing.T) {
 
 	cmd := "false"
 	results := make(chan *JobResult)
-	b := New(address, tube, 0, cmd, results)
+	b := New(context.Background(), address, tube, 0, cmd, results)
 
 	ticks := make(chan bool)
 	defer close(ticks)
@@ -79,7 +80,7 @@ func TestWorkerTimeout(t *testing.T) {
 
 	cmd := "sleep 4"
 	results := make(chan *JobResult)
-	b := New(address, tube, 0, cmd, results)
+	b := New(context.Background(), address, tube, 0, cmd, results)
 
 	ticks := make(chan bool)
 	defer close(ticks)

--- a/broker/broker_test.go
+++ b/broker/broker_test.go
@@ -28,7 +28,11 @@ func TestWorkerSuccess(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel() // cancel the context to stop the broker
 
-	b := New(ctx, address, tube, 0, cmd, results)
+	jobReceived := make(chan struct{})
+	defer close(jobReceived)
+	go devNull(jobReceived)
+
+	b := New(ctx, address, tube, 0, cmd, results, jobReceived)
 
 	ticks := make(chan bool)
 	defer close(ticks)
@@ -57,10 +61,14 @@ func TestWorkerFailure(t *testing.T) {
 	cmd := "false"
 	results := make(chan *JobResult)
 
+	jobReceived := make(chan struct{})
+	defer close(jobReceived)
+	go devNull(jobReceived)
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel() // cancel the context to stop the broker
 
-	b := New(ctx, address, tube, 0, cmd, results)
+	b := New(ctx, address, tube, 0, cmd, results, jobReceived)
 
 	ticks := make(chan bool)
 	defer close(ticks)
@@ -82,6 +90,12 @@ func TestWorkerFailure(t *testing.T) {
 	assertJobStat(t, id, "pri", "10")
 }
 
+func devNull(jobReceived chan struct{}) {
+	for range jobReceived {
+		// do nothing
+	}
+}
+
 func TestWorkerTimeout(t *testing.T) {
 	ttr := 1 * time.Second
 	tube, id := queueJob("TestWorkerTimeout", 10, ttr)
@@ -89,10 +103,14 @@ func TestWorkerTimeout(t *testing.T) {
 	cmd := "sleep 4"
 	results := make(chan *JobResult)
 
+	jobReceived := make(chan struct{})
+	defer close(jobReceived)
+	go devNull(jobReceived)
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel() // cancel the context to stop the broker
 
-	b := New(ctx, address, tube, 0, cmd, results)
+	b := New(ctx, address, tube, 0, cmd, results, jobReceived)
 
 	ticks := make(chan bool)
 	defer close(ticks)

--- a/broker/broker_test.go
+++ b/broker/broker_test.go
@@ -24,7 +24,11 @@ func TestWorkerSuccess(t *testing.T) {
 
 	cmd := "tr [a-z] [A-Z]"
 	results := make(chan *JobResult)
-	b := New(context.Background(), address, tube, 0, cmd, results)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel() // cancel the context to stop the broker
+
+	b := New(ctx, address, tube, 0, cmd, results)
 
 	ticks := make(chan bool)
 	defer close(ticks)
@@ -52,7 +56,11 @@ func TestWorkerFailure(t *testing.T) {
 
 	cmd := "false"
 	results := make(chan *JobResult)
-	b := New(context.Background(), address, tube, 0, cmd, results)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel() // cancel the context to stop the broker
+
+	b := New(ctx, address, tube, 0, cmd, results)
 
 	ticks := make(chan bool)
 	defer close(ticks)
@@ -80,7 +88,11 @@ func TestWorkerTimeout(t *testing.T) {
 
 	cmd := "sleep 4"
 	results := make(chan *JobResult)
-	b := New(context.Background(), address, tube, 0, cmd, results)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel() // cancel the context to stop the broker
+
+	b := New(ctx, address, tube, 0, cmd, results)
 
 	ticks := make(chan bool)
 	defer close(ticks)

--- a/cli/options.go
+++ b/cli/options.go
@@ -29,6 +29,9 @@ type Options struct {
 
 	// The beanstalkd tubes to watch.
 	Tubes TubeList
+
+	// Maximum number of jobs to process before exitting.
+	MaxJobs uint64
 }
 
 // TubeList is a list of beanstalkd tube names.
@@ -54,6 +57,7 @@ func ParseFlags() (o Options, err error) {
 	flag.BoolVar(&o.All, "all", false, "Listen to all tubes, instead of -tubes=...")
 	flag.StringVar(&o.Cmd, "cmd", "", "Command to run in worker.")
 	flag.Uint64Var(&o.PerTube, "per-tube", 1, "Number of workers per tube.")
+	flag.Uint64Var(&o.MaxJobs, "max-jobs", 0, "Maximum number of items to process before exitting. Zero for no limit.")
 	flag.Var(&o.Tubes, "tubes", "Comma separated list of tubes.")
 	flag.Parse()
 

--- a/cmdstalk.go
+++ b/cmdstalk.go
@@ -41,7 +41,7 @@ func main() {
 		cancel()
 	}()
 
-	bd := broker.NewBrokerDispatcher(ctx, opts.Address, opts.Cmd, opts.PerTube)
+	bd := broker.NewBrokerDispatcher(ctx, opts.Address, opts.Cmd, opts.PerTube, opts.MaxJobs)
 
 	if opts.All {
 		bd.RunAllTubes()

--- a/cmdstalk.go
+++ b/cmdstalk.go
@@ -20,6 +20,11 @@
 package main
 
 import (
+	"context"
+	"log"
+	"os"
+	"os/signal"
+
 	"github.com/99designs/cmdstalk/broker"
 	"github.com/99designs/cmdstalk/cli"
 )
@@ -27,7 +32,16 @@ import (
 func main() {
 	opts := cli.MustParseFlags()
 
-	bd := broker.NewBrokerDispatcher(opts.Address, opts.Cmd, opts.PerTube)
+	c := make(chan os.Signal)
+	signal.Notify(c, os.Interrupt)
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		<-c
+		log.Println("received interrupt. quitting.")
+		cancel()
+	}()
+
+	bd := broker.NewBrokerDispatcher(ctx, opts.Address, opts.Cmd, opts.PerTube)
 
 	if opts.All {
 		bd.RunAllTubes()
@@ -35,7 +49,5 @@ func main() {
 		bd.RunTubes(opts.Tubes)
 	}
 
-	// TODO: wire up to SIGTERM handler etc.
-	exitChan := make(chan bool)
-	<-exitChan
+	bd.Wait()
 }


### PR DESCRIPTION
Use case: I have 100k items I'd like to process when my system is under low
load. By submitting 100 `batch`[1] jobs doing

    cmdstalk -cmd=my-script.sh -max-jobs 1000

I know processing will halt as soon as load is above 0.8 (or whatever
`batch` is configured to).

[1] https://www.centos.org/docs/5/html/Deployment_Guide-en-US/s1-autotasks-at-batch.html